### PR TITLE
feature: Make logs return gatt sync progress

### DIFF
--- a/Sources/BTKit/Devices/Ruuvi/RuuviDevice.swift
+++ b/Sources/BTKit/Devices/Ruuvi/RuuviDevice.swift
@@ -554,11 +554,11 @@ public extension RuuviTag {
         }
     }
     
-    func log<T: AnyObject>(for observer: T, from date: Date, result: @escaping (T, Result<[RuuviTagEnvLogFull], BTError>) -> Void) {
+    func log<T: AnyObject>(for observer: T, from date: Date, result: @escaping (T, Result<Progressable, BTError>) -> Void) {
         log(for: observer, from: date, options: nil, result: result)
     }
     
-    func log<T: AnyObject>(for observer: T, from date: Date, options: BTScannerOptionsInfo?, result: @escaping (T, Result<[RuuviTagEnvLogFull], BTError>) -> Void) {
+    func log<T: AnyObject>(for observer: T, from date: Date, options: BTScannerOptionsInfo?, result: @escaping (T, Result<Progressable, BTError>) -> Void) {
         if !isConnectable {
             let info = BTKitParsedOptionsInfo(options)
             info.callbackQueue.execute {


### PR DESCRIPTION
This allows to receive the points count at the time of GATT sync. 